### PR TITLE
✨ Add stop_configuration_service

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,6 @@
   <exec_depend>rospy</exec_depend>
   <exec_depend>python-rospkg</exec_depend>
   <exec_depend>metacontrol_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
 
 </package>
-


### PR DESCRIPTION
@marioney I want to add the ability to stop configurations. 
I want to use this in the case that a FuncDesign has other Functions as dependency. So the dependent Functions are triggered when a FunctionDesign needs it and then when the parent FunctionDesign is reconfigured I want to have the ability to stop the dependent Functions. Something like in the figure below. 
Does this make sense?
I tested this code and it seems to work. 

![image](https://user-images.githubusercontent.com/20564040/138767795-3f994a31-3d6a-4483-8324-3ed0304d5e80.png)
